### PR TITLE
Fixed Github action workflow

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install cosign
         run: |
-          curl -LO https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64
+          curl -LO https://github.com/sigstore/cosign/releases/download/v2.6.0/cosign-linux-amd64
           chmod +x cosign-linux-amd64
           sudo mv cosign-linux-amd64 /usr/local/bin/cosign
 


### PR DESCRIPTION
Fixed Github action workflow.
Fixing cosign binary to 2.6.0 release. 
cosign has brought in some breaking changes with new v3.0 release.  See here - https://github.com/sigstore/cosign/releases

We can take them later not immediate concern hence falling back on previous version. 